### PR TITLE
FIX--141 - project name input bug

### DIFF
--- a/packages/editor/src/app/pages/workspace/components/header/_workspace-header.scss
+++ b/packages/editor/src/app/pages/workspace/components/header/_workspace-header.scss
@@ -68,6 +68,7 @@
     padding-bottom: 0;
     border-width: 2px;
     border-color: transparent;
+    max-width: 47vw;
 
     &:hover {
       border-color: $input-border-color;


### PR DESCRIPTION
Should we be limiting the length of the project name? I've just limited the max width of the input for now so that the other page elements remain in place, but the user can still continue typing and can scroll through horizontally